### PR TITLE
Remove all use of threadpool adn replace it by the new Executor from the task manager module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,9 @@ target_sources(${PROJECT_NAME}
 		src/app/threads/render/RenderThread.cpp
 		src/app/threads/render/CascadedShadowMapping.cpp
 		src/app/threads/update/UpdateThread.cpp
-		src/app/threads/pool/ThreadPool.cpp
-		src/app/threads/pool/ThreadPoolAccessor.cpp
+		src/app/threads/task_manager/ExecutorWorker.cpp
+		src/app/threads/task_manager/Executor.cpp
+		src/app/threads/task_manager/ExecutorAccessor.cpp
 		src/app/threads/block_update/BlockUpdateThread.cpp
 		src/app/threads/network/NetworkThread.cpp
 		src/app/vulkan/VulkanAPI.cpp
@@ -216,11 +217,10 @@ target_sources(server
 		src/app/threads/render/RenderThread.cpp
 		src/app/threads/render/CascadedShadowMapping.cpp
 		src/app/threads/update/UpdateThread.cpp
-		src/app/threads/pool/ThreadPool.cpp
-		src/app/threads/pool/ThreadPoolAccessor.cpp
 		src/app/threads/block_update/ServerBlockUpdateThread.cpp
 		src/app/threads/network/NetworkThread.cpp
 		src/app/threads/task_manager/ExecutorWorker.cpp
+		src/app/threads/task_manager/ExecutorAccessor.cpp
 		src/app/threads/task_manager/Executor.cpp
 		src/app/vulkan/VulkanAPI.cpp
 		src/app/vulkan/VulkanMemoryAllocator.cpp
@@ -345,8 +345,6 @@ target_link_libraries(server glfw vulkan dl pthread X11 Xxf86vm Xrandr Xi Tracy:
 # 		src/app/threads/Status.cpp
 # 		src/app/threads/render/RenderThread.cpp
 # 		src/app/threads/render/CascadedShadowMapping.cpp
-# 		src/app/threads/pool/ThreadPool.cpp
-# 		src/app/threads/pool/ThreadPoolAccessor.cpp
 # 		src/app/vulkan/VulkanAPI.cpp
 # 		src/app/vulkan/VulkanMemoryAllocator.cpp
 # 		src/app/vulkan/chunk_mesh.cpp

--- a/src/app/application.hpp
+++ b/src/app/application.hpp
@@ -9,7 +9,6 @@
 #include "VulkanAPI.hpp"
 #include "BlockUpdateThread.hpp"
 #include "NetworkThread.hpp"
-#include "ThreadPool.hpp"
 #include "Client.hpp"
 #include "SoundEngine.hpp"
 #include "EventManager.hpp"
@@ -43,4 +42,5 @@ private:
 	UpdateThread		m_update_thread;
 	BlockUpdateThread	m_block_update_thread;
 	NetworkThread		m_network_thread;
+
 };

--- a/src/app/threads/block_update/BlockUpdateThread.hpp
+++ b/src/app/threads/block_update/BlockUpdateThread.hpp
@@ -3,7 +3,6 @@
 #include "define.hpp"
 #include "ClientWorld.hpp"
 #include "VulkanAPI.hpp"
-#include "ThreadPool.hpp"
 #include "DebugGui.hpp"
 #include "Tracy.hpp"
 #include "tracy_globals.hpp"

--- a/src/app/threads/block_update/ServerBlockUpdateThread.hpp
+++ b/src/app/threads/block_update/ServerBlockUpdateThread.hpp
@@ -4,7 +4,6 @@
 #include "Tracy.hpp"
 #include "tracy_globals.hpp"
 #include "ServerWorld.hpp"
-#include "ThreadPool.hpp"
 
 /**
  * @brief An implementation of the thread wrapper for the thread that handles block updates

--- a/src/app/threads/network/NetworkThread.hpp
+++ b/src/app/threads/network/NetworkThread.hpp
@@ -5,7 +5,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
 #include "VulkanAPI.hpp"
-#include "ThreadPool.hpp"
 #include "DebugGui.hpp"
 #include "logger.hpp"
 #include "Tracy.hpp"

--- a/src/app/threads/task_manager/ExecutorAccessor.cpp
+++ b/src/app/threads/task_manager/ExecutorAccessor.cpp
@@ -1,0 +1,61 @@
+#include "ExecutorAccessor.hpp"
+
+ExecutorAccessor::ExecutorAccessor()
+: m_executor(task::Executor::getInstance())
+{
+}
+
+ExecutorAccessor::~ExecutorAccessor()
+{
+	waitForAll();
+}
+
+void ExecutorAccessor::waitForAll()
+{
+	while (!m_futures.empty())
+	{
+		auto it = m_futures.begin();
+		waitTask(it->first);
+	}
+}
+
+void ExecutorAccessor::waitForFinishedTasks()
+{
+	std::lock_guard<std::mutex> lock(m_futures_mutex);
+	std::lock_guard<std::mutex> lock2(m_finished_tasks_mutex);
+	while (!m_finished_tasks.empty())
+	{
+		uint64_t id = *m_finished_tasks.begin();
+		m_finished_tasks.erase(m_finished_tasks.begin());
+
+		auto & future = m_futures.at(id);
+		future.get();
+		m_futures.erase(id);
+	}
+}
+
+void ExecutorAccessor::waitForTask(uint64_t id)
+{
+	std::lock_guard<std::mutex> lock(m_futures_mutex);
+	waitTask(id);
+}
+
+void ExecutorAccessor::waitForTasks(const std::vector<uint64_t> & ids)
+{
+	std::lock_guard<std::mutex> lock(m_futures_mutex);
+	for (auto id : ids)
+		waitTask(id);
+}
+
+void ExecutorAccessor::waitTask(uint64_t id)
+{
+	// LOG_INFO("Waiting for task " << id);
+	auto & future = m_futures.at(id);
+	future.get();
+	m_futures.erase(id);
+	{
+		std::lock_guard<std::mutex> lock(m_finished_tasks_mutex);
+		m_finished_tasks.erase(id);
+	}
+}
+

--- a/src/app/threads/task_manager/ExecutorAccessor.hpp
+++ b/src/app/threads/task_manager/ExecutorAccessor.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "logger.hpp"
+#include "Executor.hpp"
+#include <functional>
+#include <unordered_set>
+
+
+class ExecutorAccessor
+{
+public:
+	ExecutorAccessor();
+	~ExecutorAccessor();
+
+	ExecutorAccessor(const ExecutorAccessor &) = delete;
+	ExecutorAccessor & operator=(const ExecutorAccessor &) = delete;
+	ExecutorAccessor(ExecutorAccessor &&) = delete;
+	ExecutorAccessor & operator=(ExecutorAccessor &&) = delete;
+
+	/**
+	 * @brief Submit a task to the threadpool, the task will be executed asynchronously
+	 * 
+	 * @tparam F return type of the function
+	 * @param f function to execute
+	 * @return id of the task, you can use this id to wait for the task to finish
+	 */
+	template<typename F>
+	uint64_t submit(F && f)
+	{
+		std::lock_guard<std::mutex> lock(m_futures_mutex);
+
+		typedef typename std::invoke_result<F>::type result_type;
+		//create a packaged task with the function
+		std::shared_ptr<std::packaged_task<result_type()>> task_ptr = std::make_shared<std::packaged_task<result_type()>>(std::move(f));
+
+		//encapsulate inside another void function with error handling + id tracking
+		uint64_t id = m_counter++;
+		std::function<void()> wrapper_func = [task_ptr = std::move(task_ptr), this, id] () mutable
+		{
+			std::exception_ptr eptr = nullptr;
+			auto future = task_ptr->get_future();
+			(*task_ptr)();
+
+			try
+			{
+				future.get();
+			}
+			catch (...)
+			{
+				eptr = std::current_exception();
+			}
+
+			{
+				std::lock_guard<std::mutex> lock(m_finished_tasks_mutex);
+				m_finished_tasks.insert(id);
+			}
+
+			if (eptr != nullptr)
+				std::rethrow_exception(eptr);
+		};
+
+		//submit the task to the thread pool
+		std::future<void> future_v = m_executor.run(wrapper_func);
+		m_futures.insert(std::make_pair(id, std::move(future_v)));
+
+		return id;
+	}
+
+	/**
+	 * @brief wait for all tasks to finish
+	 */
+	void waitForAll();
+
+	/**
+	 * @brief wait for all finished task
+	 */
+	void waitForFinishedTasks();
+
+	/**
+	 * @brief wait for a specific task to finish
+	 * 
+	 * @param id id of the task to wait for
+	 */
+	void waitForTask(uint64_t id);
+
+	/**
+	 * @brief wait for a list of tasks to finish
+	 * 
+	 * @param ids std::vector of ids of the tasks to wait for
+	 */
+	void waitForTasks(const std::vector<uint64_t> & ids);
+private:
+	task::Executor &									m_executor;
+	uint64_t											m_counter = 0;
+
+	std::unordered_set<uint64_t>						m_finished_tasks;
+	std::mutex											m_finished_tasks_mutex;
+	std::unordered_map<uint64_t, std::future<void>>		m_futures;
+	std::mutex 											m_futures_mutex;
+
+	/**
+	 * @brief waits a task
+	 * @warning you must lock m_mutex BEFORE calling this function
+	 * 
+	 * @param id 
+	 */
+	void waitTask(uint64_t id);
+};

--- a/src/app/world/ClientWorld.cpp
+++ b/src/app/world/ClientWorld.cpp
@@ -28,7 +28,7 @@ void ClientWorld::updateBlock(glm::dvec3 position)
 	ZoneScoped;
 	updateChunks(position);
 	// waitForFinishedFutures();
-	m_threadPool.waitForFinishedTasks();
+	m_executor.waitForFinishedTasks();
 }
 
 // void ClientWorld::update(glm::dvec3 nextPlayerPosition)
@@ -89,7 +89,7 @@ void ClientWorld::unloadChunk(const glm::ivec3 & chunkPos3D)
 
 	if (chunk == nullptr)
 		return;
-	m_threadPool.submit([this, chunk]()
+	m_executor.submit([this, chunk]()
 	{
 		ZoneScopedN("Chunk Unloading");
 		/**************************************************************
@@ -188,7 +188,7 @@ void ClientWorld::meshChunk(const glm::ivec2 & chunkPos2D)
 	/********
 	* PUSHING TASK TO THREAD POOL
 	********/
-	m_threadPool.submit([this, chunkPos3D, mesh_data = std::move(mesh_data)]() mutable
+	m_executor.submit([this, chunkPos3D, mesh_data = std::move(mesh_data)]() mutable
 	{
 		ZoneScopedN("Chunk Meshing");
 		/**************************************************************
@@ -295,9 +295,6 @@ void ClientWorld::doBlockSets()
 		if (m_blocks_to_set.empty())
 			return;
 	}
-	// uint64_t current_id = m_future_id++;
-	// std::future<void> future = m_threadPool.submit([this, current_id]()
-	// {
 		while(1)
 		{
 			glm::vec3 position;

--- a/src/app/world/ServerWorld.cpp
+++ b/src/app/world/ServerWorld.cpp
@@ -2,7 +2,8 @@
 
 ServerWorld::ServerWorld(Server & server)
 :	World(),
-	m_server(server)
+	m_server(server),
+	m_executor(task::Executor::getInstance())
 {
 	addTicket({Ticket::Type::OTHER, SPAWN_TICKET_LEVEL, glm::ivec3(0, 0, 0)});
 	// std::shared_ptr<Chunk> chunk;
@@ -106,8 +107,6 @@ void ServerWorld::waitForChunkFutures()
 
 	std::lock_guard lock(m_chunk_gen_data.m_chunk_gen_data_mutex);
 	m_chunk_gen_data.future.get();
-	// m_threadPool.waitForTasks(m_chunk_futures_ids);
-	// m_chunk_futures_ids.clear();
 }
 
 void ServerWorld::updateTickedValues()

--- a/src/app/world/ServerWorld.hpp
+++ b/src/app/world/ServerWorld.hpp
@@ -4,7 +4,6 @@
 #include "Server.hpp"
 #include "Packets.hpp"
 #include "World.hpp"
-#include "ThreadPool.hpp"
 #include "server_define.hpp"
 #include "logger.hpp"
 #include <unordered_set>
@@ -161,7 +160,7 @@ private:
 	 * NETWORK
 	\*********************************/
 	Server & m_server;
-	task::Executor m_executor;
+	task::Executor & m_executor;
 	std::unordered_map<uint64_t, uint64_t> m_player_to_connection_id;
 	std::unordered_map<uint64_t, uint64_t> m_connection_to_player_id;
 	TracyLockableN(std::mutex, m_players_info_mutex, "PlayerInfoMutex");

--- a/src/app/world/ServerWorldBlocks.cpp
+++ b/src/app/world/ServerWorldBlocks.cpp
@@ -272,24 +272,6 @@ ChunkMap ServerWorld::getChunkZone(glm::ivec3 zoneStart, glm::ivec3 zoneSize)
 	return chunks;
 }
 
-// uint64_t ServerWorld::asyncGenChunk(const glm::ivec3 & chunkPos3D, Chunk::genLevel gen_level , Chunk::genLevel current_gen_level = Chunk::genLevel::EMPTY)
-// {
-// 	ChunkMap chunksToGen;
-// 	WorldGenerator::genInfo info = m_world_generator.getGenInfo(gen_level, current_gen_level, chunkPos3D);
-
-// 	chunksToGen = getChunkZone(info.zoneStart, info.zoneSize);
-
-// 	return m_threadPool.submit([this, info, chunksToGen] () mutable
-// 	{
-// 		ZoneScopedN("Generate Chunk");
-// 		// m_world_generator.generateChunkColumn(chunkPos3D.x, chunkPos3D.z, chunk);
-// 		m_world_generator.generate(info, chunksToGen);
-
-// 		for (auto & [chunk_position, chunk] : chunksToGen)
-// 			chunk->status.unlock();
-// 	});
-// }
-
 void ServerWorld::doChunkGens(WorldGenerator::ChunkGenList & chunks_to_gen)
 {
 	ZoneScoped;

--- a/src/app/world/World.hpp
+++ b/src/app/world/World.hpp
@@ -4,7 +4,7 @@
 #include "Player.hpp"
 #include "WorldGenerator.hpp"
 #include "logger.hpp"
-#include "ThreadPoolAccessor.hpp"
+#include "ExecutorAccessor.hpp"
 #include "tasks.hpp"
 #include "Mob.hpp"
 #include "hashes.hpp"
@@ -252,7 +252,7 @@ protected:
 	std::unordered_map<glm::ivec3, std::shared_ptr<Chunk>>	m_chunks;
 	mutable TracyLockableN									(std::mutex,	m_chunks_mutex, "Chunks");
 
-	ThreadPoolAccessor 									m_threadPool;
+	ExecutorAccessor 									m_executor;
 
 
 	WorldGenerator										m_world_generator;

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -20,7 +20,6 @@ int main()
 {
 	logger.configure("log_server");
 	LOG_INFO("Server started");
-	// ThreadPool threadPool;
 	signal(SIGINT, [](int signum) {
 		running = false;
 	});


### PR DESCRIPTION
I hate c++ and ref forwarding and function casting.
fixes #130 